### PR TITLE
allow xml attributes

### DIFF
--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -98,7 +98,13 @@ exports.create = function(options, callback) {
       values.forEach(function (value) {
         var valueElement = doc.createElementNS(NAMESPACE, 'saml2:AttributeValue');
         valueElement.setAttribute('xsi:type', 'xs:anyType');
-        valueElement.textContent = value;
+        if(value[0] === '<'){ //parse xml attribute values and append them
+          var attributeValue = new Parser().parseFromString(value);
+          valueElement.appendChild(attributeValue);
+        }
+        else {
+          valueElement.textContent = value;
+        }
         attributeElement.appendChild(valueElement);
       });
 

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -65,7 +65,9 @@ describe('saml 2.0', function () {
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
         'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
         'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://undefinedattribute/ws/com.com': undefined
+        'http://undefinedattribute/ws/com.com': undefined,
+        'urn:oasis:names:tc:xspa:1.0:subject:organization': '<PurposeOfUse xmlns="urn:hl7-org:v3" xsi:type="CE" code="TREATMENT" codeSystem="2.16.840.1.113883.3.18.7.1" codeSystemName="nhin-purpose" displayName="Treatment"/>'
+
       }
     };
 
@@ -74,14 +76,16 @@ describe('saml 2.0', function () {
     var isValid = utils.isValidSignature(signedAssertion, options.cert);
     assert.equal(true, isValid);
 
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(3, attributes.length);
+
+    var attributes = utils.getsaml2Attributes(signedAssertion);
+    assert.equal(4, attributes.length);
     assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
     assert.equal('foo@bar.com', attributes[0].textContent);
     assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
     assert.equal('Foo Bar', attributes[1].textContent);
     assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
     assert.equal('fóo', attributes[2].textContent);
+    assert.equal('PurposeOfUse',attributes[3].firstChild.firstChild.nodeName)
   });
 
   it('whole thing with specific authnContextClassRef', function () {

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -85,7 +85,7 @@ describe('saml 2.0', function () {
     assert.equal('Foo Bar', attributes[1].textContent);
     assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
     assert.equal('fóo', attributes[2].textContent);
-    assert.equal('PurposeOfUse',attributes[3].firstChild.firstChild.nodeName)
+    assert.equal('PurposeOfUse',attributes[3].firstChild.firstChild.nodeName);
   });
 
   it('whole thing with specific authnContextClassRef', function () {

--- a/test/utils.js
+++ b/test/utils.js
@@ -96,3 +96,9 @@ exports.getEncryptedData = function(encryptedAssertion) {
   return doc.documentElement
             .getElementsByTagName('xenc:EncryptedData')[0];
 };
+
+exports.getsaml2Attributes = function(assertion) {
+  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  return doc.documentElement
+            .getElementsByTagName('saml2:Attribute');
+};


### PR DESCRIPTION
This PR adds support for rendering XML strings as proper XML in attributes. 

Without this change, the XML gets escaped as if it were just a string.